### PR TITLE
Add AUDB thing

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.raindb.net

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.raindb.net

--- a/index.html
+++ b/index.html
@@ -1821,7 +1821,7 @@
         //////////////////////////////////////////////////////////////////////////////////
 	var ModsAUDB15 = [];
 	var request = new XMLHttpRequest();
-	request.open('GET', 'https://audb.pythonanywhere.com/api/raindb', true);
+	request.open('GET', 'https://beestuff.pythonanywhere.com/audb/api/raindb', true);
 	request.send();
 	request.onreadystatechange = function() {
 		if (request.readyState == XMLHttpRequest.DONE) {

--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
                 generateHTML("utilities", ToolMods, "", "Modding Tools");
             else if (section == "1.01mods")
                 generateHTML("1.01", Mods101, "", "v1.01 Mods");
+            else if (section == "AUDB1.5mods")
+                generateHTML("AUDB1.5", ModsAUDB15, "", "AUDB Mods");
             else if (section == "arenas")
                 generateArenaHTML("arena", Arenas, "");
             else if (section == "palettes")
@@ -1813,6 +1815,20 @@
             "thumb":  "previews/literallyunplayable_preview.jpg",
             "desc":   "Cycles are now 10x shorter. Godspeed you magnificent bastard.<br>Note: only works with pre-made saves."
         });
+	    
+        //////////////////////////////////////////////////////////////////////////////////
+        // AUDB VERSION 1.5 MODS
+        //////////////////////////////////////////////////////////////////////////////////
+	var ModsAUDB15 = [];
+	var request = new XMLHttpRequest();
+	request.open('GET', 'https://audb.pythonanywhere.com/api/raindb', true);
+	request.send();
+	request.onreadystatechange = function() {
+		if (request.readyState == XMLHttpRequest.DONE) {
+			ModsAUDB15.push.apply(ModsAUDB15, JSON.parse(request.resultText));
+		}
+	};
+	
 
         toggle("1.5mods");
 

--- a/index.html
+++ b/index.html
@@ -1825,7 +1825,7 @@
 	request.send();
 	request.onreadystatechange = function() {
 		if (request.readyState == XMLHttpRequest.DONE) {
-			ModsAUDB15.push.apply(ModsAUDB15, JSON.parse(request.resultText));
+			ModsAUDB15.push.apply(ModsAUDB15, JSON.parse(request.responseText));
 		}
 	};
 	

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>RainDB - Home</title>
 
     <script>
-        var sections = ["1.01mods", "1.5mods", "1.7mods", "utilities", "arenas", "palettes"];
+        var sections = ["1.01mods", "1.5mods", "1.7mods", "utilities", "AUDB1.5mods", "arenas", "palettes"];
         function toggle(section) {
             if (section == "1.5mods")
                 generateHTML("1.5", Mods15, "", "v1.5 Mods");

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-sm-6 section-description wow fadeIn animated" style="visibility: visible; animation-name: fadeIn; text-align:left; float:left; margin-left:5px;">
-                   <b>Mod Category:</b> <a onclick="toggle('1.01mods')" href="#main">v1.01</a> | <a onclick="toggle('1.5mods')" href="#main">v1.5</a> | <!--<a onclick="toggle('1.7mods')" href="#main">v1.7</a> |--> <a onclick="toggle('arenas')" href="#main">Arenas</a> | <a onclick="toggle('utilities')" href="#main">Tools</a> | <a onclick="toggle('palettes'); getRecolorFunct(0)();" href="#main">Palettes</a>
+                   <b>Mod Category:</b> <a onclick="toggle('1.01mods')" href="#main">v1.01</a> | <a onclick="toggle('1.5mods')" href="#main">v1.5</a> | <!--<a onclick="toggle('1.7mods')" href="#main">v1.7</a> |-->  <a onclick="toggle('AUDB1.5mods')" href="#main">AUDB</a> | <a onclick="toggle('arenas')" href="#main">Arenas</a> | <a onclick="toggle('utilities')" href="#main">Tools</a> | <a onclick="toggle('palettes'); getRecolorFunct(0)();" href="#main">Palettes</a>
                 </div>
                 <div class="col-sm-4 section-description wow fadeIn animated" style="visibility: visible; animation-name: fadeIn; text-align:right; float:right; margin-left:5px;">
                    <b>Legend:</b> <img class="legendTooltip_0" src="assets/ico/standalone.png" title="Standalone Mod: These mods are installed alone. They cannot be used together with other standalone mods."/> 
@@ -186,6 +186,12 @@
                 <h3><b>Rain World v1.7 has just recently been released!<br>Please be patient as we confirm compatibility with old mods, and update mods to the new version.</b></h3>
 
                 <div id="1.7_gallery"></div>
+            </div>
+
+            <div id="AUDB1.5mods" style="display:none;">
+                <div id="AUDB1.5_title"></div>
+                <div class="divider-1" style="visibility: visible; animation-name: fadeInUp;"><span></span></div>
+                <div id="AUDB1.5_gallery"></div>
             </div>
 
             <div id="utilities" style="display:none;">


### PR DESCRIPTION
This adds an AUDB tab that has mods from AUDB in it. Mods will only appear if they have all of the metadata (mod type, name, author name, etc.) required to get put on RainDB (this is handled on the AUDB side in the /api/raindb endpoint, because when you make your own API you can add your own stuff to it). So... yep.

On discord, we're @pastebin.com/q3BTYZc9#3020 a.k.a. "bee (female, she/they/it)", and we also created AUDB. Also we're bad at writing. And tired. Sorry.