### PR TITLE
Update links in tutorials.html

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -97,8 +97,8 @@
                     Any number of these types of mods can be used together at the same time, using BepInEx.
                     <br><br>
                     <ol>
-                        <li><a href="https://drive.google.com/file/d/1WcCCsS3ABBdO1aX-iJGeqeE07YE4Qv88/view" target="_blank">Download BepInEx</a> and extract the contents of the zip file into your Rain World folder.</li>
-                        <li><a href="https://github.com/thalber/BOI/releases/" target="_blank">Download BOI Mod Manager</a> and extract it anywhere.</li>
+                        <li><a href="https://beestuff.pythonanywhere.com/audb/api/v2/bepinex/download" target="_blank">Download BepInEx</a> and extract the contents of the zip file into your Rain World folder.</li>
+                        <li><a href="https://github.com/Rain-World-Modding/BOI/releases/" target="_blank">Download BOI Mod Manager</a> and extract it anywhere.</li>
                         <li>Run "BlepOutIn.exe"</li>
                         <li>Press "Select Path", navigate to your Rain World folder, and select it.</li>
                         <li>Click the "Press again to load modlist" button.</li>


### PR DESCRIPTION
Old google drive download for bepinex -> bepinex download straight from AUDB (which is always the newest version)
Old github link for BOI (stuck at version 0.1.5) -> new github link for BOI after the move to Rain-World-Modding

\- bee