### PR TITLE
Update RWGG URL

### DIFF
--- a/legacy.html
+++ b/legacy.html
@@ -1143,7 +1143,7 @@
             "name":   "Rain World GeoGuessr",
             "author": "Kerotoric",
             "type":   "External Game",
-            "url":    "http://isaacelenbaas.us.to/RWGG/RWGG.html",
+            "url":    "https://RWGG.isaacelenbaas.com/RWGG.html",
             "thumb":  "previews/geoguessr.png",
             "desc":   "A clone of the popular location guessing game GeoGuessr using Rain World's map. Includes multiplayer lobbies.",
             "app": true,


### PR DESCRIPTION
Though the old URL forwards to the new, the domain switch was because some DNS providers do not resolve the old one. In those cases it would still not be reachable.