### PR TITLE
World Editor 1.9 Link

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -465,7 +465,7 @@
             "name":   "World Editor",
             "author": "Bro",
             "type":   "Utility",
-            "url":    "https://drive.google.com/file/d/1nSxDXC210Sf_eeR3VpMAw4xhs4grKCKw/view",
+            "url":    "https://github.com/Bro748/World-Editor/releases/latest",
             "thumb":  "previews/worldedit.png",
             "desc":   "An editor for assembling world and map files. Has features for connecting and positioning rooms, creatures spawns, and more.",
             "app": true,


### PR DESCRIPTION
Currently raindb links to World Editor for 1.5, which doesn't work for 1.9, which is what most people want