### PR TITLE
index.html: autofocus the search box on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-sm-6 section-description wow fadeIn animated" style="visibility: visible; animation-name: fadeIn; text-align:left; float:left; margin-left:5px;">
-                   <b>Search:</b> <input type="text" id="mod-search" name="search" onchange="doSearch(this.value)" autocomplete="off" spellcheck="false">
+                   <b>Search:</b> <input type="text" id="mod-search" name="search" onchange="doSearch(this.value)" autocomplete="off" spellcheck="false" autofocus>
                 </div>
                 <div class="col-sm-4 section-description wow fadeIn animated" style="visibility: visible; animation-name: fadeIn; text-align:right; float:right; margin-left:5px;">
                     <b>Filter by Tag:</b> <select name="tag_filter" id="tag_filter" onchange="filterChanged()">


### PR DESCRIPTION
when index.html is loaded, the added `autofocus` tag will automatically focus the mod-search input box. Typing on keyboard from there will directly write to the search box
this allows easier usage of the website, as most people come to search for a term or a mod instead of just scrolling through the list.
I tested it on a web browser (firefox), and the tag is supported across all major web browsers (https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
as for mobile device behavior, it did not automatically make the keyboard appear (but then again, most people will go on PC web browser so that's fime)