### PR TITLE
Sharing links

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,6 +254,9 @@
         document.addEventListener('click', function(e){   
           if (!document.getElementById('infobox').contains(e.target)){
             document.getElementById('infobox').style['display'] = 'none';
+            if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
+                !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
+            ) window.location.hash = ""
           }
         });
 
@@ -277,8 +280,9 @@
             }
             if (modinfo === null)
                 return;
-
+            // let urlWithoutHash = window.location.origin + window.location.pathname;
             document.getElementById('infobox_title').innerHTML = modinfo['name'];
+            document.getElementById('infobox_title').href = "#" + modinfo['workshop_id']
             if (!('workshop_id' in modinfo) || modinfo['workshop_id'] === "")
                 document.getElementById('infobox_workshopurl').href = modinfo['url'];
             else
@@ -330,6 +334,7 @@
                 document.getElementById('infobox_dependency_warning').style['display'] = 'none';
 
             setTimeout(()=>{document.getElementById('infobox').style['display'] = 'block';}, 100);
+            window.location.hash = "#" + workshop_id
         }
 
         function stripSteamTags(text) {
@@ -493,7 +498,7 @@
                 if ("thumb" in mods_array[i])
                     useThumb = mods_array[i]["thumb"];
                 appendStr += '<img src="' + useThumb + '?raw=true" alt="" data-ax2x="' + useThumb + '?raw=true" style="width:360px;height:203px;cursor: pointer;" onclick="showInfoboxWithModInfo(\'' + mods_array[i]["workshop_id"] + '\')"></div>';
-                appendStr += '<h3 style="margin-top:8px"><a style="cursor: pointer" onclick="showInfoboxWithModInfo(\'' + mods_array[i]["workshop_id"] + '\')" style="margin-left: 0px; margin-top: -1px;" target="_blank"><b>' + mods_array[i]["name"] + '</b></a>';
+                appendStr += '<h3 style="margin-top:8px"><a style="cursor: pointer" onclick="showInfoboxWithModInfo(\'' + mods_array[i]["workshop_id"] + '\'); return false;" style="margin-left: 0px; margin-top: -1px;" target="_blank" href=#' + mods_array[i]["workshop_id"] + '><b>' + mods_array[i]["name"] + '</b></a>';
                 
                 // Icons
                 if ("video" in mods_array[i])
@@ -559,6 +564,10 @@
         }
 
         toggle("mods");
+
+        if (window.location.hash != "") {
+            showInfoboxWithModInfo(window.location.hash.slice(1))
+        }
     </script>
 
     <!-- Footer -->

--- a/index.html
+++ b/index.html
@@ -257,18 +257,20 @@
             if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
                 !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
             ) history.replaceState(null, document.title, window.location.pathname + window.location.search);
+
           }
         });
 
-        document.addEventListener('keydown', function(e) {
-            if (!document.getElementById('infobox').contains(e.target)){
-            document.getElementById('infobox').style['display'] = 'none';
-            if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
-                !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
-            ) history.replaceState(null, document.title, window.location.pathname + window.location.search);
-          }
+        document.addEventListener('keydown', function(event) {
+            if (event.key === 'Escape') {
+                if (!document.getElementById('infobox').contains(e.target)) {
+                        document.getElementById('infobox').style['display'] = 'none';
+                    if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
+                        !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
+                    ) history.replaceState(null, document.title, window.location.pathname + window.location.search);
+                }
+            }
         });
-        
 
 
         window.addEventListener("scroll", loadOnScroll);

--- a/index.html
+++ b/index.html
@@ -257,9 +257,19 @@
             if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
                 !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
             ) history.replaceState(null, document.title, window.location.pathname + window.location.search);
-
           }
         });
+
+        document.addEventListener('keydown', function(e) {
+            if (!document.getElementById('infobox').contains(e.target)){
+            document.getElementById('infobox').style['display'] = 'none';
+            if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
+                !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
+            ) history.replaceState(null, document.title, window.location.pathname + window.location.search);
+          }
+        });
+        
+
 
         window.addEventListener("scroll", loadOnScroll);
 

--- a/index.html
+++ b/index.html
@@ -256,7 +256,8 @@
             document.getElementById('infobox').style['display'] = 'none';
             if (!e.target.parentElement.onclick?.toString().includes("showInfoboxWithModInfo(") && 
                 !e.target.onclick?.toString().includes("showInfoboxWithModInfo(")
-            ) window.location.hash = ""
+            ) history.replaceState(null, document.title, window.location.pathname + window.location.search);
+
           }
         });
 

--- a/index.html
+++ b/index.html
@@ -280,9 +280,7 @@
             }
             if (modinfo === null)
                 return;
-            // let urlWithoutHash = window.location.origin + window.location.pathname;
             document.getElementById('infobox_title').innerHTML = modinfo['name'];
-            document.getElementById('infobox_title').href = "#" + modinfo['workshop_id']
             if (!('workshop_id' in modinfo) || modinfo['workshop_id'] === "")
                 document.getElementById('infobox_workshopurl').href = modinfo['url'];
             else


### PR DESCRIPTION
Sharing links would allow people to share the link to a specific mod amongst themselves.
They would look like this: https://andrewfm.github.io/RainDB#3022284148, here the hash is 3022284148 which is the workshop ID of that mod
- If loading the page with a hash, try to open its details (around line 567)
- When opening a mod details, update current url with the one that leads to that mod's details (so that one can copy-paste current url to share a mod). This does not make the webpage reload. (around line 337)
- Added the sharing URL on the <a> element of each mod's little box so that users can right click and copy a sharing url without opening its preview (around line 496)

Please do let me know if you have any questions or anything regarding that.
Here's a link to the deployment on my pages so that you can see how it looks ! https://autodistries.github.io/RainDB/#3008202773